### PR TITLE
Typo and Grammar Corrections on Getting Started Page

### DIFF
--- a/source/get-started/index.html
+++ b/source/get-started/index.html
@@ -23,17 +23,17 @@ layout: page
             <div class="col-md-4">
               <h3>Usage and Examples</h3>
               <p>
-                Usages guidelines help you decide when and how to use each pattern.  You can also find differenct examples and pick up what will work best.
+                Usage guidelines help you decide when and how to use each pattern.  You can also find different examples and pick up what will work best.
               </p>
             </div>
             <div class="col-md-4">
               <h3>Design</h3>
-              <p>Following the guildelines will ensure the consistent look and feel across difference applications.</p>
+              <p>Following the guidelines will ensure the consistent look and feel across different applications.</p>
             </div>
             <div class="col-md-4">
               <h3>Usability Tests</h3>
               <p>
-                If usability has been performed on a specific pattern, you will see a summary to the results.
+                If usability has been performed on a specific pattern, you will see a summary of the results.
               </p>
             </div>
           </div>
@@ -50,7 +50,7 @@ layout: page
         <div class="col-sm-8 col-md-9 col-lg-9">
           <h2>Code</h2>
           <p>
-            The latest version of PatternFly provides code samples built on the top of both Bootstrap 3 and Angular JS.  Developers will have more flexibilities when building their own applications.  Check out the Reference Implementation and Angular JS tabs for more details!
+            The latest version of PatternFly provides code samples built on the top of both Bootstrap 3 and Angular JS.  Developers will have more flexibility when building their own applications.  Check out the Reference Implementation and Angular JS tabs for more details!
           </p>
           <ul class="list-unstyled">
             <li>
@@ -91,7 +91,7 @@ layout: page
         <div class="col-sm-8 col-md-9 col-lg-9">
           <h2>Community</h2>
           <p>
-            Want to get involved in the PatternFly community?  Connet with us via social media and mailing list!  Don’t forget that there are multiple ways to collaborate with other contributors and keep up-to-date.
+            Want to get involved in the PatternFly community?  Connect with us via social media and mailing list!  Don’t forget that there are multiple ways to collaborate with other contributors and keep up-to-date.
           </p>
           <p>
             <a href="{{site.baseurl}}community/">Learn more</a>


### PR DESCRIPTION
Usage and Examples - There's a typo "Usages guidelines" (Usage
guidelines")
Design - There's a typo "guildelines" (guidelines)
Design  - There's a typo "difference" (different)
Usability Tests  - There's a typo "to the results" (of the results)
Code  - There's a typo "flexibilities" (flexibility)
Community  - There's a typo in "Connet" (Connect)